### PR TITLE
fixed unused slider variable

### DIFF
--- a/examples/rfnoc/rfnoc_fir_tx.grc
+++ b/examples/rfnoc/rfnoc_fir_tx.grc
@@ -697,7 +697,7 @@
     </param>
     <param>
       <key>freq</key>
-      <value>1.982e9</value>
+      <value>tx_freq</value>
     </param>
     <param>
       <key>rate</key>


### PR DESCRIPTION
There's a slider for "tx_freq", which is by default set to 920MHz, but never
used by the Radio; instead, it was set to 1.9something GHz constant.