### PR TITLE
uhd path and findscript fixes

### DIFF
--- a/python/rfnoc_modtool/rfnoc-newmod/cmake/Modules/Findfpga.cmake
+++ b/python/rfnoc_modtool/rfnoc-newmod/cmake/Modules/Findfpga.cmake
@@ -3,13 +3,13 @@ PKG_CHECK_MODULES(PC_FPGA fpga)
 
 FIND_PATH(
     UHD_FPGA_DIR
-    NAMES /usrp3/top/Makefile.common
+    NAMES /usrp3_rfnoc/top/Makefile.common
     HINTS $ENV{PYBOMBS_PREFIX}/src/uhd-fpga
         ${PC_FPGA_INCLUDEDIR}
-    PATHS ${CMAKE_INSTALL_PREFIX}/src/uhd-fpga/usrp3
+        ~/src/uhd/fpga-src
+    PATHS ${CMAKE_INSTALL_PREFIX}/src/uhd-fpga/usrp3_rfnoc
 )
 
 INCLUDE(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(FPGA DEFAULT_MSG UHD_FPGA_DIR)
 MARK_AS_ADVANCED(UHD_FPGA_DIR)
-

--- a/python/rfnoc_modtool/rfnoc-newmod/cmake/setupenv.sh
+++ b/python/rfnoc_modtool/rfnoc-newmod/cmake/setupenv.sh
@@ -1,1 +1,1 @@
-source FPGA_TOP_DIR/usrp3/top/e300/setupenv.sh
+source FPGA_TOP_DIR/usrp3_rfnoc/top/x300/setupenv.sh

--- a/python/rfnoc_modtool/templates.py
+++ b/python/rfnoc_modtool/templates.py
@@ -1016,7 +1016,7 @@ Templates['tb_makefile'] = '''
 \# Top-of-Makefile
 \#-------------------------------------------------
 \# Define BASE_DIR to point to the "top" dir
-BASE_DIR = FPGA_TOP_DIR/usrp3/top
+BASE_DIR = FPGA_TOP_DIR/usrp3_rfnoc/top
 \# Include viv_sim_preample after defining BASE_DIR
 include \$(BASE_DIR)/../tools/make/viv_sim_preamble.mak
 


### PR DESCRIPTION
With the current uhd version, I needed to perform these changes to get gr-ettus working. I had to change `usrp3` directories to `usrp3_rfnoc` and also added the common path `~/src/uhd/fpga-src` to the hints in the cmake Findfpga script.