### PR TITLE
Added analog bandwidth option to RFNOC Radio Source

### DIFF
--- a/grc/uhd_rfnoc_radio.xml
+++ b/grc/uhd_rfnoc_radio.xml
@@ -27,6 +27,7 @@
     $radio_index, $device_index
 )
 self.$(id).set_rate($rate)
+self.$(id).set_bandwidth($rx_bandwidth)
 for i in xrange($num_channels):
     self.$(id).set_${direction}_freq($freq, i)
     self.$(id).set_${direction}_gain($gain, i)
@@ -143,6 +144,13 @@ for i in xrange($num_channels):
     <name>Gain</name>
     <key>gain</key>
     <value>20</value>
+    <type>real</type>
+    <tab>RF Options</tab>
+  </param>
+  <param>
+    <name>Analog Bandwidth (Hz)</name>
+    <key>rx_bandwidth</key>
+    <value>56e6</value>
     <type>real</type>
     <tab>RF Options</tab>
   </param>

--- a/include/ettus/rfnoc_radio.h
+++ b/include/ettus/rfnoc_radio.h
@@ -66,6 +66,7 @@ namespace gr {
       virtual void set_tx_dc_offset(const std::complex< double > &offset, const size_t chan=0) = 0;
       virtual void set_rx_dc_offset(bool enable, const size_t chan=0) = 0;
       virtual void set_rx_dc_offset(const std::complex< double > &offset, const size_t chan=0) = 0;
+      virtual void set_bandwidth(const double bandwidth, const size_t chan=0) = 0;
 
       virtual std::vector<std::string> get_gpio_banks() const = 0;
       virtual void set_gpio_attr(

--- a/lib/rfnoc_radio_impl.cc
+++ b/lib/rfnoc_radio_impl.cc
@@ -86,6 +86,11 @@ namespace gr {
       _radio_ctrl->set_rx_gain(gain, chan);
     }
 
+    void rfnoc_radio_impl::set_bandwidth(const double bandwidth, const size_t chan)
+    {
+      _radio_ctrl->set_rx_bandwidth(bandwidth, chan);
+    }
+
     void rfnoc_radio_impl::set_tx_antenna(const std::string &ant, const size_t chan)
     {
       _radio_ctrl->set_tx_antenna(ant, chan);

--- a/lib/rfnoc_radio_impl.h
+++ b/lib/rfnoc_radio_impl.h
@@ -44,6 +44,7 @@ namespace gr {
       void set_rx_freq(const double freq, const size_t chan);
       void set_tx_gain(const double gain, const size_t chan);
       void set_rx_gain(const double gain, const size_t chan);
+      void set_bandwidth(const double bandwidth, const size_t chan);
       void set_tx_antenna(const std::string &ant, const size_t chan);
       void set_rx_antenna(const std::string &ant, const size_t chan);
       void set_tx_dc_offset(bool enable, const size_t chan);


### PR DESCRIPTION
These updates depends on exposing the set_rx_bandwidth function in the radio_ctrl in the UHD repo. PR here: https://github.com/EttusResearch/uhd/pull/85