### PR TITLE
rfnoc_block_impl: check for existing block_port stream_arg before overriding

### DIFF
--- a/grc/uhd_rfnoc_radio.xml
+++ b/grc/uhd_rfnoc_radio.xml
@@ -27,10 +27,11 @@
     $radio_index, $device_index
 )
 self.$(id).set_rate($rate)
-for i in xrange($num_channels):
+for idx, i in enumerate($channel_map):
     self.$(id).set_${direction}_freq($freq, i)
     self.$(id).set_${direction}_gain($gain, i)
     self.$(id).set_${direction}_dc_offset($dcenable, i)
+    self.$(id).set_${direction}_port_chan_map(idx, i)
 #if (str($direction()) == "rx")
 
 self.$(id).set_rx_bandwidth($rx_bandwidth0, 0)
@@ -56,9 +57,9 @@ self.$(id).set_clock_source(${source})
 </make>
 <callback>self.$(id).set_rate($rate)</callback>
 <callback>self.$(id).set_bandwidth($rx_bandwidth)</callback>
-<callback>for i in xrange($num_channels):
+<callback>for i in $channel_map:
     self.$(id).set_${direction}_freq($freq, i)</callback>
-<callback>for i in xrange($num_channels):
+<callback>for i in $channel_map:
     self.$(id).set_${direction}_gain($gain, i)</callback>
 <callback>self.$(id).set_${direction}_antenna($ant0)</callback>
 <callback>self.$(id).set_${direction}_antenna($ant1)</callback>
@@ -112,6 +113,13 @@ self.$(id).set_rx_lo_source($lo_source1, "all", 1)
       <name>1 Channel</name>
       <key>1</key>
     </option>
+  </param>
+
+  <param>
+    <name>Channel Map</name>
+    <key>channel_map</key>
+    <value>[0]</value>
+    <type>int_vector</type>
   </param>
 
   <param>
@@ -440,6 +448,8 @@ self.$(id).set_rx_lo_source($lo_source1, "all", 1)
      </option>
      <tab>Advanced</tab>
   </param>
+
+  <check>$num_channels == len($channel_map)</check>
 
   <sink>
     <name>in</name>

--- a/include/ettus/rfnoc_radio.h
+++ b/include/ettus/rfnoc_radio.h
@@ -107,6 +107,9 @@ namespace gr {
       virtual uhd::time_spec_t get_time_last_pps(void) = 0;
       virtual void set_command_time(const uhd::time_spec_t &time, const size_t chan=0) = 0;
       virtual void clear_command_time(const size_t chan=0) = 0;
+
+      virtual void set_rx_port_chan_map(const size_t port, const size_t chan) = 0;
+      virtual void set_tx_port_chan_map(const size_t port, const size_t chan) = 0;
     };
 
   } // namespace ettus

--- a/lib/rfnoc_radio_impl.cc
+++ b/lib/rfnoc_radio_impl.cc
@@ -231,6 +231,16 @@ namespace gr {
       _radio_ctrl->set_gpio_attr(bank, attr, value, mask);
     }
 
+    void rfnoc_radio_impl::set_rx_port_chan_map(const size_t port, const size_t chan)
+    {
+      _radio_ctrl->set_rx_port_chan_map(port, chan);
+    }
+
+    void rfnoc_radio_impl::set_tx_port_chan_map(const size_t port, const size_t chan)
+    {
+      _radio_ctrl->set_tx_port_chan_map(port, chan);
+    }
+
     uint32_t rfnoc_radio_impl::get_gpio_attr(const std::string &bank, const std::string &attr)
     {
       return _radio_ctrl->get_gpio_attr(bank, attr);

--- a/lib/rfnoc_radio_impl.h
+++ b/lib/rfnoc_radio_impl.h
@@ -97,6 +97,8 @@ namespace gr {
       void set_command_time(const uhd::time_spec_t &time, const size_t chan);
       void clear_command_time(const size_t chan);
 
+      void set_rx_port_chan_map(const size_t port, const size_t chan);
+      void set_tx_port_chan_map(const size_t port, const size_t chan);
      private:
       ::uhd::rfnoc::radio_ctrl::sptr _radio_ctrl;
 


### PR DESCRIPTION
Current implementation of rfnoc_block_impl:start() will enforce the block_port stream_arg of unaligned streamers is *always* set to the channel of the gnuradio flowgraph; this approach prohibits use of channel 1 without also using channel 0.

I'm simply running a check now to see if a specialized block_port per channel is provided to the stream args. If so, do NOT override based on the flowgraph port. 