### PR TITLE
RFNoC DDC: Added gr_vlen to stream args 

### DIFF
--- a/grc/uhd_rfnoc_ddc.xml
+++ b/grc/uhd_rfnoc_ddc.xml
@@ -9,13 +9,13 @@
         cpu_format="fc32", \# TODO: This must be made an option
         otw_format="sc16",
         channels=range($num_chans),
-        args="input_rate={},output_rate={},fullscale={},freq={}".format($input_rate, $output_rate, $fullscale, $freq),
+        args="input_rate={},output_rate={},fullscale={},freq={},gr_vlen={},{}".format($input_rate, $output_rate, $fullscale, $freq, ${grvlen}, "" if $grvlen == 1 else "spp={}".format($grvlen)),
     ),
     uhd.stream_args( \# RX Stream Args
         cpu_format="fc32", \# TODO: This must be made an option
         otw_format="sc16",
         channels=range($num_chans),
-        args="",
+        args="gr_vlen={},{}".format(${grvlen}, "" if $grvlen == 1 else "spp={}".format($grvlen)),
     ),
     "DDC", $block_index, $device_index,
 )


### PR DESCRIPTION
When using the vector length argument with the RFNoC DDC block, issues like 
> ValueError: itemsize mismatch: uhd_rfnoc_DDC0:0 using 8, vector_to_stream0:0 using 1024

might occur (minimal working example grc flowgraph attached).

This fix resolves that issue by adding `gr_vlen` to the stream args.

![rfnoc_ddc_error](https://user-images.githubusercontent.com/28390772/35615322-1236166c-0672-11e8-9f8c-cc53b48e768b.png)

