### PR TITLE
rfnoc_register_probe: GRC plugin to query RFNoC registers

### DIFF
--- a/grc/ettus_block_tree.xml
+++ b/grc/ettus_block_tree.xml
@@ -35,6 +35,8 @@
 			<block>uhd_rfnoc_streamer_siggen</block>
 			<block>uhd_rfnoc_streamer_dma_fifo</block>
 			<block>uhd_rfnoc_digital_gain</block>
+			<block>uhd_rfnoc_register_logger</block>
+			<block>uhd_rfnoc_register_probe</block>
 		</cat>
 	</cat>
 </cat>

--- a/grc/uhd_rfnoc_register_logger.xml
+++ b/grc/uhd_rfnoc_register_logger.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<block>
+  <name>RFNoC: Register Logger</name>
+  <key>uhd_rfnoc_register_logger</key>
+  <import>from ettus import rfnoc_register_probe</import>
+  <make>rfnoc_register_probe.rfnoc_register_probe(1.0 / ($poll_rate), $enable, $csvfile, $debug)
+self.temp_$(id)_stop = self.stop
+def stop_$(id)_fcn():
+    self.$(id).shutdown()
+    self.temp_$(id)_stop()
+self.stop = stop_$(id)_fcn</make>
+  <param>
+    <name>Poll Rate (Hz)</name>
+    <key>poll_rate</key>
+    <value>1</value>
+    <type>real</type>
+  </param>
+  <param>
+    <name>Filename</name>
+    <key>csvfile</key>
+    <value>"probe.csv"</value>
+  </param>
+  <param>
+    <name>Enable Logger</name>
+    <key>enable</key>
+    <value>True</value>
+    <type>bool</type>
+    <option>
+      <name>Enabled</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>Disabled</name>
+      <key>False</key>
+    </option>
+  </param>
+  <param>
+    <name>Console Output</name>
+    <key>debug</key>
+    <value>True</value>
+    <type>bool</type>
+    <option>
+      <name>Enabled</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>Disabled</name>
+      <key>False</key>
+    </option>
+  </param>
+</block>

--- a/grc/uhd_rfnoc_register_probe.xml
+++ b/grc/uhd_rfnoc_register_probe.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<block>
+  <name>RFNoC: Register Probe</name>
+  <key>uhd_rfnoc_register_probe</key>
+  <import>from ettus import rfnoc_register_probe</import>
+  <make>#set $logger = 'self' + ('.' + $logger_id() if $logger_id() else '')
+#set $block = 'self' + ('.' + $block_id() if $block_id() else '')
+$(logger).add_query($block, $registers)</make>
+  <param>
+    <name>RFNoC Logger ID</name>
+    <key>logger_id</key>
+    <value>rfnoc_register_logger_0</value>
+    <type>string</type>
+  </param>
+  <param>
+    <name>RFNoC Block ID</name>
+    <key>block_id</key>
+    <value>rfnoc_block_0</value>
+    <type>string</type>
+  </param>
+  <param>
+    <name>Register List</name>
+    <key>registers</key>
+    <value>["reg0","reg1"]</value>
+  </param>
+</block>

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,6 +32,7 @@ GR_PYTHON_INSTALL(
     FILES
     __init__.py
     fosphor_histo_framer.py
+    rfnoc_register_probe.py
     DESTINATION ${GR_PYTHON_DIR}/ettus
 )
 

--- a/python/rfnoc_register_probe.py
+++ b/python/rfnoc_register_probe.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python2
+import time
+import datetime
+import threading
+
+class rfnoc_register_probe():
+    def __init__(self, looptime=1.0, enable=True, csvout=None, console=False):
+        self.looptime = looptime
+        self.csvout   = csvout
+        self.console  = console
+        self.queries  = []
+        self.running  = False
+        self.halt     = False
+        self.file     = None
+        if enable:
+            if self.console:
+                print("\nInitialized RFNoC Probe...")
+
+            # TODO: Figure out how to call start after adding queries?
+            self.start()
+        else:
+            # not enabled
+            pass
+
+    def add_query(self, nocblock, registers):
+        newquery = {"block": nocblock, "registers": registers}
+        self.queries.append(newquery)
+
+        # Overwrite the old CSV...
+        # TODO: figure out how to add blocks without overwriting current CSV
+        self.opencsv()
+
+    def query(self):
+        # Loop through the queries and get register values
+        results = []
+        for probe in self.queries:
+            block = probe["block"]
+            regs  = probe["registers"]
+            for reg in regs:
+                val = block.get_register(reg)
+                results.append((block.get_block_id(), reg, val))
+        return results
+
+    def opencsv(self):
+        # Re-open the CSV
+        if self.file:
+            self.file.close()
+        self.file = None
+        if self.csvout:
+            self.file = open(self.csvout, "w")
+            strnames = []
+            for probe in self.queries:
+                block = probe["block"]
+                regs  = probe["registers"]
+                for reg in regs:
+                    strnames.append("%s/%s" % (block.get_block_id(), reg))
+            csvheader = ",".join(["time"]+strnames)
+            self.file.write("%s\n" % (csvheader))
+
+    def start(self):
+        # self.opencsv()
+        self.halt = False
+        self.running = True
+        self.runthread = threading.Thread(target=self.runloop)
+        self.runthread.daemon = True
+        self.runthread.start()
+
+    def runloop(self):
+        print("\nStarting RFNoC probe loop")
+        while not self.halt:
+            try:
+                # Sleep for desired looptime
+                time.sleep(self.looptime)
+
+                # Query RFNoC registers
+                results = self.query()
+                values = [v for (_, _, v) in results]
+
+                # Debug output
+                if self.console:
+                    if results:
+                        print("\nQuerying RFNoC blocks...")
+                    for block, reg, val in results:
+                        print("%s/%s: %s" % (block, str(reg), str(val)))
+
+                # File output
+                if self.file:
+                    newline = ",".join([str(datetime.datetime.now())]+[str(val) for val in values])
+                    self.file.write("%s\n" % (newline))
+            except Exception as e:
+                print("\nCaught error in rfnoc_register_logger.runloop(): %s" % (e))
+                print(e)
+                break
+        self.running = False
+
+    def shutdown(self):
+        if self.running:
+            print("Ending RFNoC probe loop")
+        self.halt = True
+        while self.running:
+            if self.console:
+                print("Waiting for RFNoC probe to shutdown...")
+            time.sleep(self.looptime)
+        if self.file:
+            self.file.close()
+
+    def __del__(self):
+        self.shutdown()


### PR DESCRIPTION
I thought I would toss this PR here for discussion. This combination of GRC-based "Logger" and "Probe" objects lets me easily read back RFNoC registers when a flowgraph is running. I'll provide example usage below.

There's two main components:
 1. uhd_rfnoc_register_logger: Defines the logger properties
 2. uhd_rfnoc_register_probe: Defines the registers to probe on a "per-block" basis

There should be ONE "Register Logger" per flowgraph. There may be multiple "Register Probes" in a flowgraph; one probe PER RFNoC block. I'm aware we could perhaps combine these roles into a single GRC block, which would be a valid approach. However, I've been happy with this two-block solution because each Register Probe maps one-to-one per RFNoC block -- so I can copy/paste a Register Probe into a new GRC flowgraph (which may or may not have a different set of *other* Register Probes) and maintain the same register logging for my RFNoC block of interest.

Here's an example flowgraph where I'm initializing one "Logger" object, which runs at 1 Hz, prints to console, and also prints to a file named probe.csv. I'm also initializing two RFNoC probes, one per RFNoC block in my flowgraph. I've specified a list of registers to for the logger to read back during program operations:

![image](https://user-images.githubusercontent.com/613471/36346214-3335cdc8-1408-11e8-8d5f-674d0e28da5c.png)

Here's example parameters for one of the RFNoC "Probe" blocks, which is in this case attaching to the "fpgacomms_he360encoder_0" block,  and reading a few status registers.

![image](https://user-images.githubusercontent.com/613471/36346219-4ff81826-1408-11e8-9df2-2764b75f8ebb.png)

Here's an example console output for a different application that's querying a number of registers:

```
Querying RFNoC blocks...
0/syrlinks_0/RB_TX_HDLC_PACKETS: 1314
0/syrlinks_0/RB_TX_HDLC_BYTES: 2693514
0/syrlinks_0/RB_TX_HDLC_FILLFRAMES: 32049
0/syrlinks_0/RB_TX_RS_BLOCKS: 12248
0/syrlinks_0/RB_TX_RS_BYTES: 3124179

Querying RFNoC blocks...
0/syrlinks_0/RB_TX_HDLC_PACKETS: 2646
0/syrlinks_0/RB_TX_HDLC_BYTES: 5421139
0/syrlinks_0/RB_TX_HDLC_FILLFRAMES: 32049
0/syrlinks_0/RB_TX_RS_BLOCKS: 24501
0/syrlinks_0/RB_TX_RS_BYTES: 6248614

Querying RFNoC blocks...
0/syrlinks_0/RB_TX_HDLC_PACKETS: 2730
0/syrlinks_0/RB_TX_HDLC_BYTES: 5588996
0/syrlinks_0/RB_TX_HDLC_FILLFRAMES: 2597426
0/syrlinks_0/RB_TX_RS_BLOCKS: 36756
0/syrlinks_0/RB_TX_RS_BYTES: 9373627

Querying RFNoC blocks...
0/syrlinks_0/RB_TX_HDLC_PACKETS: 2730
0/syrlinks_0/RB_TX_HDLC_BYTES: 5588996
0/syrlinks_0/RB_TX_HDLC_FILLFRAMES: 5329727
0/syrlinks_0/RB_TX_RS_BLOCKS: 49008
0/syrlinks_0/RB_TX_RS_BYTES: 12498008

Querying RFNoC blocks...
0/syrlinks_0/RB_TX_HDLC_PACKETS: 2730
0/syrlinks_0/RB_TX_HDLC_BYTES: 5588996
0/syrlinks_0/RB_TX_HDLC_FILLFRAMES: 8061682
0/syrlinks_0/RB_TX_RS_BLOCKS: 61259
0/syrlinks_0/RB_TX_RS_BYTES: 15621983
```

Overall this has been VERY helpful for me in development and quick diagnostics of RFNoC blocks -- I suspect they could be useful for others too! Let me know any thoughts.