### PR TITLE
RFNoC PDU TX/RX Software blocks

### DIFF
--- a/grc/ettus_block_tree.xml
+++ b/grc/ettus_block_tree.xml
@@ -35,6 +35,8 @@
 			<block>uhd_rfnoc_streamer_siggen</block>
 			<block>uhd_rfnoc_streamer_dma_fifo</block>
 			<block>uhd_rfnoc_digital_gain</block>
+			<block>uhd_rfnoc_pdu_rx</block>
+			<block>uhd_rfnoc_pdu_tx</block>
 		</cat>
 	</cat>
 </cat>

--- a/grc/uhd_rfnoc_pdu_rx.xml
+++ b/grc/uhd_rfnoc_pdu_rx.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<block>
+  <name>RFNoC: PDU RX</name>
+  <key>uhd_rfnoc_pdu_rx</key>
+  <throttle>1</throttle>
+  <import>import ettus</import>
+  <make>ettus.rfnoc_pdu_rx(
+    self.device3,
+    uhd.stream_args( \# Tx Stream Args
+        cpu_format="$type",
+        otw_format="$otw_format",
+	args=""
+    ),
+    uhd.stream_args( \# Rx Stream Args
+        cpu_format="$type",
+        otw_format="$otw_format",
+        args=${stream_args}
+    ),
+    "FIFO",
+    $block_index, $device_index, $mtu)
+  </make>
+  <param>
+    <name>FIFO Select</name>
+    <key>block_index</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if int($block_index()) &lt; 0 then 'part' else 'none'#</hide>
+    <tab>RFNoC Config</tab>
+  </param>
+  <param>
+    <name>Host Data Type</name>
+    <key>type</key>
+    <type>enum</type>
+    <option>
+      <name>Complex float32</name>
+      <key>fc32</key>
+      <opt>type:complex</opt>
+    </option>
+    <option>
+      <name>Complex int16</name>
+      <key>sc16</key>
+      <opt>type:sc16</opt>
+    </option>
+    <option>
+      <name>Byte</name>
+      <key>u8</key>
+      <opt>type:byte</opt>
+    </option>
+    <option>
+      <name>VITA word32</name>
+      <key>item32</key>
+      <opt>type:s32</opt>
+    </option>
+  </param>
+  <param>
+    <name>Device Format</name>
+    <key>otw_format</key>
+    <type>enum</type>
+    <option>
+      <name>Complex int16</name>
+      <key>sc16</key>
+    </option>
+    <option>
+      <name>Complex int8</name>
+      <key>sc8</key>
+    </option>
+    <option>
+      <name>Byte</name>
+      <key>u8</key>
+    </option>
+  </param>
+  <param>
+    <name>Device Select</name>
+    <key>device_index</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if int($device_index()) &lt; 0 then 'part' else 'none'#</hide>
+    <tab>RFNoC Config</tab>
+  </param>
+  <param>
+    <name>MTU</name>
+    <key>mtu</key>
+    <value>2048</value>
+    <type>int</type>
+  </param>
+  <param>
+    <name>Force Vector Length</name>
+    <key>grvlen</key>
+    <value>1</value>
+    <type>int</type>
+  </param>
+  <sink>
+    <name>in</name>
+    <type>$type.type</type>
+    <vlen>$grvlen</vlen>
+    <domain>rfnoc</domain>
+  </sink>
+  <source>
+    <name>data</name>
+    <type>message</type>
+    <optional>1</optional>
+  </source>
+</block>

--- a/grc/uhd_rfnoc_pdu_tx.xml
+++ b/grc/uhd_rfnoc_pdu_tx.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<block>
+  <name>RFNoC: PDU TX</name>
+  <key>uhd_rfnoc_pdu_tx</key>
+  <throttle>1</throttle>
+  <import>import ettus</import>
+  <make>ettus.rfnoc_pdu_tx(
+    self.device3,
+    uhd.stream_args( \# Tx Stream Args
+        cpu_format="$type",
+        otw_format="$otw_format",
+        args=${stream_args}
+    ),
+    uhd.stream_args( \# Rx Stream Args
+        cpu_format="$type",
+        otw_format="$otw_format",
+        args=""
+    ),
+    "FIFO",
+    $block_index, $device_index)
+  </make>
+  <param>
+    <name>FIFO Select</name>
+    <key>block_index</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if int($block_index()) &lt; 0 then 'part' else 'none'#</hide>
+    <tab>RFNoC Config</tab>
+  </param>
+  <param>
+    <name>Host Data Type</name>
+    <key>type</key>
+    <type>enum</type>
+    <option>
+      <name>Complex float32</name>
+      <key>fc32</key>
+      <opt>type:complex</opt>
+    </option>
+    <option>
+      <name>Complex int16</name>
+      <key>sc16</key>
+      <opt>type:sc16</opt>
+    </option>
+    <option>
+      <name>Byte</name>
+      <key>u8</key>
+      <opt>type:byte</opt>
+    </option>
+    <option>
+      <name>VITA word32</name>
+      <key>item32</key>
+      <opt>type:s32</opt>
+    </option>
+  </param>
+  <param>
+    <name>Device Format</name>
+    <key>otw_format</key>
+    <type>enum</type>
+    <option>
+      <name>Complex int16</name>
+      <key>sc16</key>
+    </option>
+    <option>
+      <name>Complex int8</name>
+      <key>sc8</key>
+    </option>
+    <option>
+      <name>Byte</name>
+      <key>u8</key>
+    </option>
+  </param>
+  <param>
+    <name>Device Select</name>
+    <key>device_index</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if int($device_index()) &lt; 0 then 'part' else 'none'#</hide>
+    <tab>RFNoC Config</tab>
+  </param>
+  <param>
+    <name>Force Vector Length</name>
+    <key>grvlen</key>
+    <value>1</value>
+    <type>int</type>
+  </param>
+  <sink>
+    <name>data</name>
+    <type>message</type>
+    <optional>1</optional>
+  </sink>
+  <source>
+    <name>out</name>
+    <type>$type.type</type>
+    <vlen>$grvlen</vlen>
+    <domain>rfnoc</domain>
+  </source>
+</block>

--- a/include/ettus/CMakeLists.txt
+++ b/include/ettus/CMakeLists.txt
@@ -31,6 +31,8 @@ install(FILES
     rfnoc_radio.h
     rfnoc_generic.h
     rfnoc_fosphor_c.h
+    rfnoc_pdu_tx.h
+    rfnoc_pdu_rx.h
     DESTINATION include/ettus
 )
 

--- a/include/ettus/rfnoc_block_impl.h
+++ b/include/ettus/rfnoc_block_impl.h
@@ -54,7 +54,7 @@ namespace gr {
       /*********************************************************************
        * GR Block functions
        *********************************************************************/
-      int general_work(
+      virtual int general_work(
           int noutput_items,
           gr_vector_int &ninput_items,
           gr_vector_const_void_star &input_items,
@@ -62,8 +62,8 @@ namespace gr {
        );
 
       bool check_topology(int ninputs, int noutputs);
-      bool start();
-      bool stop();
+      virtual bool start();
+      virtual bool stop();
 
       /**********************************************************************
        * Structors
@@ -156,20 +156,20 @@ namespace gr {
       /*********************************************************************
        * Workers and Helpers
        *********************************************************************/
-      void work_tx_a(
+      virtual void work_tx_a(
           gr_vector_int &ninput_items,
           gr_vector_const_void_star &input_items
       );
-      void work_tx_u(
+      virtual void work_tx_u(
           gr_vector_int &ninput_items,
           gr_vector_const_void_star &input_items
       );
 
-      int work_rx_a(
+      virtual int work_rx_a(
           int noutput_items,
           gr_vector_void_star &output_items
       );
-      void work_rx_u(
+      virtual void work_rx_u(
           int noutput_items,
           gr_vector_void_star &output_items
       );
@@ -193,7 +193,7 @@ namespace gr {
       //! Translate the RFNoC block's output signature into a GNU Radio output signature
       gr::io_signature::sptr get_rfnoc_output_signature();
 
-     private:
+     protected:
       /*********************************************************************
        * Private attributes
        ********************************************************************/

--- a/include/ettus/rfnoc_pdu_rx.h
+++ b/include/ettus/rfnoc_pdu_rx.h
@@ -1,0 +1,63 @@
+/* -*- c++ -*- */
+/* Copyright 2015 Ettus Research
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * gr-ettus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gr-ettus; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_ETTUS_RFNOC_PDU_RX_H
+#define INCLUDED_ETTUS_RFNOC_PDU_RX_H
+
+#include <ettus/api.h>
+#include <ettus/device3.h>
+#include <ettus/rfnoc_block.h>
+
+namespace gr {
+  namespace ettus {
+
+    /*!
+     * \brief RFNoC fosphor block
+     * \ingroup ettus
+     */
+    class ETTUS_API rfnoc_pdu_rx : virtual public rfnoc_block
+    {
+     public:
+      typedef boost::shared_ptr<rfnoc_pdu_rx> sptr;
+
+      /*!
+       * \param dev device3 instance
+       * \param tx_stream_args Tx Stream Args
+       * \param rx_stream_args Tx Stream Args
+       * \param block_name Block name, e.g. "FFT"
+       * \param block_select Block select
+       * \param device_select Device select
+       * \param mtu max packet size 
+       */
+      static sptr make(
+          const device3::sptr &dev,
+          const ::uhd::stream_args_t &tx_stream_args,
+          const ::uhd::stream_args_t &rx_stream_args,
+	  const std::string &block_name,
+          const int block_select,
+          const int device_select=-1,
+	  const int mtu=2048
+      );
+    };
+
+  } // namespace ettus
+} // namespace gr
+
+#endif /* INCLUDED_ETTUS_RFNOC_FOSPHOR_C_H */
+

--- a/include/ettus/rfnoc_pdu_tx.h
+++ b/include/ettus/rfnoc_pdu_tx.h
@@ -1,0 +1,61 @@
+/* -*- c++ -*- */
+/* Copyright 2015 Ettus Research
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * gr-ettus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gr-ettus; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_ETTUS_RFNOC_PDU_H
+#define INCLUDED_ETTUS_RFNOC_PDU_H
+
+#include <ettus/api.h>
+#include <ettus/device3.h>
+#include <ettus/rfnoc_block.h>
+
+namespace gr {
+  namespace ettus {
+
+    /*!
+     * \brief RFNoC fosphor block
+     * \ingroup ettus
+     */
+    class ETTUS_API rfnoc_pdu_tx : virtual public rfnoc_block
+    {
+     public:
+      typedef boost::shared_ptr<rfnoc_pdu_tx> sptr;
+
+      /*!
+       * \param dev device3 instance
+       * \param tx_stream_args Tx Stream Args
+       * \param rx_stream_args Tx Stream Args
+       * \param block_name Block name, e.g. "FFT"
+       * \param block_select Block select
+       * \param device_select Device select
+       */
+      static sptr make(
+          const device3::sptr &dev,
+          const ::uhd::stream_args_t &tx_stream_args,
+          const ::uhd::stream_args_t &rx_stream_args,
+	  const std::string &block_name,
+          const int block_select,
+          const int device_select=-1
+      );
+    };
+
+  } // namespace ettus
+} // namespace gr
+
+#endif /* INCLUDED_ETTUS_RFNOC_FOSPHOR_C_H */
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,6 +41,8 @@ list(APPEND ettus_sources
     rfnoc_radio_impl.cc
     rfnoc_generic_impl.cc
     rfnoc_fosphor_c_impl.cc
+    rfnoc_pdu_tx_impl.cc
+    rfnoc_pdu_rx_impl.cc
 )
 
 if(ENABLE_QT)

--- a/lib/rfnoc_pdu_rx_impl.cc
+++ b/lib/rfnoc_pdu_rx_impl.cc
@@ -1,0 +1,210 @@
+/* -*- c++ -*- */
+/* Copyright 2015 Ettus Research
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * gr-ettus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-ettus; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include <gnuradio/gr_complex.h>
+#include <pmt/pmt.h>
+#include "rfnoc_pdu_rx_impl.h"
+
+namespace gr {
+  namespace ettus {
+
+    rfnoc_pdu_rx::sptr
+    rfnoc_pdu_rx::make(
+        const device3::sptr &dev,
+        const ::uhd::stream_args_t &tx_stream_args,
+        const ::uhd::stream_args_t &rx_stream_args,
+        const std::string &block_name,
+        const int block_select,
+        const int device_select,
+        const int mtu
+    ) {
+      return gnuradio::get_initial_sptr(
+          new rfnoc_pdu_rx_impl(dev, tx_stream_args, rx_stream_args, block_name, block_select, device_select, mtu)
+      );
+    }
+
+    static ::uhd::stream_args_t
+    _make_stream_args(const char *host_type, const char *otw_type, size_t spp, size_t len)
+    {
+      ::uhd::stream_args_t stream_args(host_type, otw_type);
+      stream_args.args["spp"] = str(boost::format("%s") % spp);
+      if (len > 1) {
+        stream_args.channels.clear();
+        for (size_t i=0; i<len; i++)
+          stream_args.channels.push_back(i);
+      }
+      return stream_args;
+    }
+
+
+    rfnoc_pdu_rx_impl::rfnoc_pdu_rx_impl(
+        const device3::sptr &dev,
+        const ::uhd::stream_args_t &tx_stream_args,
+        const ::uhd::stream_args_t &rx_stream_args,
+        const std::string &block_name,
+        const int block_select,
+        const int device_select,
+        const int mtu
+    ) : rfnoc_block("rfnoc_pdu_rx"),
+        rfnoc_block_impl(
+            dev,
+            rfnoc_block_impl::make_block_id(block_name, block_select, device_select),
+            tx_stream_args,
+            rx_stream_args
+        ),
+        d_started(false),
+        d_finished(false)
+    {
+      d_rxbuf.resize(mtu,0);
+      message_port_register_out(pmt::mp("data"));
+      start_rxthread(this, pmt::mp("data"));
+      set_output_signature(io_signature::make(0, 0, 0));
+    }
+
+    rfnoc_pdu_rx_impl::~rfnoc_pdu_rx_impl()
+    {
+      /* nop */
+      stop_rxthread();
+    }
+
+
+    bool rfnoc_pdu_rx_impl::start()
+    {
+      boost::recursive_mutex::scoped_lock lock(d_mutex);
+      size_t ninputs  = 0;
+      size_t noutputs = 1;
+      GR_LOG_DEBUG(d_debug_logger, str(boost::format("start(): ninputs == %d noutputs == %d") % ninputs % noutputs));
+
+      // If the topology changed, we need to clear the old streamers
+      if (_rx.streamers.size() != noutputs) {
+        _rx.streamers.clear();
+      }
+      if (_tx.streamers.size() != ninputs) {
+        _tx.streamers.clear();
+      }
+
+      // Setup RX streamer
+      if (noutputs && _rx.streamers.empty()) {
+        // Get a block control for the rx side:
+        ::uhd::rfnoc::source_block_ctrl_base::sptr rx_blk_ctrl =
+            boost::dynamic_pointer_cast< ::uhd::rfnoc::source_block_ctrl_base >(_blk_ctrl);
+        if (!rx_blk_ctrl) {
+          GR_LOG_FATAL(d_logger, str(boost::format("Not a source_block_ctrl_base: %s") % _blk_ctrl->unique_id()));
+          return false;
+        }
+        if (_rx.align) { // Aligned streamers:
+          GR_LOG_DEBUG(d_debug_logger, str(boost::format("Creating one aligned rx streamer for %d outputs.") % noutputs));
+          GR_LOG_DEBUG(d_debug_logger,
+              str(boost::format("cpu: %s  otw: %s  args: %s channels.size: %d ") % _rx.stream_args.cpu_format % _rx.stream_args.otw_format % _rx.stream_args.args.to_string() % _rx.stream_args.channels.size()));
+          assert(noutputs == _rx.stream_args.channels.size());
+          ::uhd::rx_streamer::sptr rx_stream = _dev->get_rx_stream(_rx.stream_args);
+          if (rx_stream) {
+            _rx.streamers.push_back(rx_stream);
+          } else {
+            GR_LOG_FATAL(d_logger, str(boost::format("Can't create rx streamer(s) to: %s") % _blk_ctrl->get_block_id().get()));
+            return false;
+          }
+        } else { // Unaligned streamers:
+          for (size_t i = 0; i < size_t(noutputs); i++) {
+            _rx.stream_args.channels = std::vector<size_t>(1, i);
+            std::string portkey = str(boost::format("block_port%d") % i);
+            if (!_rx.stream_args.args.has_key(portkey)) {
+              _rx.stream_args.args["block_port"] = str(boost::format("%d") % i);
+            }
+            GR_LOG_DEBUG(d_debug_logger, str(boost::format("creating rx streamer with: %s") % _rx.stream_args.args.to_string()));
+            ::uhd::rx_streamer::sptr rx_stream = _dev->get_rx_stream(_rx.stream_args);
+            if (rx_stream) {
+              _rx.streamers.push_back(rx_stream);
+            }
+          }
+          if (_rx.streamers.size() != size_t(noutputs)) {
+            GR_LOG_FATAL(d_logger, str(boost::format("Can't create rx streamer(s) to: %s") % _blk_ctrl->get_block_id().get()));
+            return false;
+          }
+        }
+      }
+
+      // Start the streamers
+      if (!_rx.streamers.empty()) {
+        ::uhd::stream_cmd_t stream_cmd(::uhd::stream_cmd_t::STREAM_MODE_START_CONTINUOUS);
+        stream_cmd.stream_now = true;
+        for (size_t i = 0; i < _rx.streamers.size(); i++) {
+          _rx.streamers[i]->issue_stream_cmd(stream_cmd);
+        }
+      }
+
+      return true;
+    }
+
+    void
+    rfnoc_pdu_rx_impl::run()
+    {
+      while(!d_finished) {
+        if( _rx.streamers.size() != 1 )
+        {
+          std::cout << "Waiting for stream to become available." << std::endl ;
+          sleep(1);
+          continue;
+        }
+        const int result = _rx.streamers[0]->recv(
+            &d_rxbuf[0],
+            d_rxbuf.size(),
+            _rx.metadata, 0.1, true
+        );
+
+        if (result < 0)
+          throw std::runtime_error("rfnoc_pdu_rx_impl, bad read!");
+
+        if( result > 0 )
+        {
+          pmt::pmt_t vector = pmt::init_u8vector(result, &d_rxbuf[0]);
+          pmt::pmt_t pdu = pmt::cons(pmt::PMT_NIL, vector);
+          d_blk->message_port_pub(d_port, pdu);
+        }
+      }
+    }
+
+    void
+    rfnoc_pdu_rx_impl::stop_rxthread()
+    {
+      d_finished = true;
+
+      if (d_started) {
+        d_thread.interrupt();
+        d_thread.join();
+      }
+    }
+
+
+    void
+    rfnoc_pdu_rx_impl::start_rxthread(basic_block *blk, pmt::pmt_t port)
+    {
+      d_blk = blk;
+      d_port = port;
+      d_thread = gr::thread::thread(boost::bind(&rfnoc_pdu_rx_impl::run, this));
+      d_started = true;
+    }
+
+  } /* namespace ettus */
+} /* namespace gr */

--- a/lib/rfnoc_pdu_rx_impl.h
+++ b/lib/rfnoc_pdu_rx_impl.h
@@ -1,0 +1,65 @@
+/* -*- c++ -*- */
+/* Copyright 2015 Ettus Research
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * gr-ettus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-ettus; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_ETTUS_RFNOC_PDU_RX_IMPL_H
+#define INCLUDED_ETTUS_RFNOC_PDU_RX_IMPL_H
+
+#include <ettus/rfnoc_pdu_rx.h>
+#include <ettus/rfnoc_block_impl.h>
+
+namespace gr {
+  namespace ettus {
+
+    enum vector_type { byte_t, float_t, complex_t };
+
+    class rfnoc_pdu_rx_impl : public rfnoc_pdu_rx, public rfnoc_block_impl
+    {
+     public:
+      rfnoc_pdu_rx_impl(
+        const device3::sptr &dev,
+        const ::uhd::stream_args_t &tx_stream_args,
+        const ::uhd::stream_args_t &rx_stream_args,
+        const std::string &block_name,
+        const int block_select,
+        const int device_select=-1,
+        const int mtu=2048
+      );
+      bool start();
+      ~rfnoc_pdu_rx_impl();
+
+
+     private:
+      bool d_started;
+      bool d_finished;
+      std::vector<uint8_t> d_rxbuf;
+      gr::thread::thread d_thread;
+
+      pmt::pmt_t d_port;
+      basic_block *d_blk;
+
+      void run();
+      void start_rxthread(basic_block *blk, pmt::pmt_t rxport);
+      void stop_rxthread();
+    };
+
+  } // namespace ettus
+} // namespace gr
+
+#endif /* INCLUDED_ETTUS_RFNOC_PDU_IMPL_H */
+

--- a/lib/rfnoc_pdu_tx_impl.cc
+++ b/lib/rfnoc_pdu_tx_impl.cc
@@ -1,0 +1,197 @@
+/* -*- c++ -*- */
+/* Copyright 2015 Ettus Research
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * gr-ettus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-ettus; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include <gnuradio/gr_complex.h>
+#include <pmt/pmt.h>
+#include "rfnoc_pdu_tx_impl.h"
+
+namespace gr {
+  namespace ettus {
+
+    rfnoc_pdu_tx::sptr
+    rfnoc_pdu_tx::make(
+        const device3::sptr &dev,
+        const ::uhd::stream_args_t &tx_stream_args,
+        const ::uhd::stream_args_t &rx_stream_args,
+        const std::string &block_name,
+        const int block_select,
+        const int device_select
+    ) {
+      return gnuradio::get_initial_sptr(
+          new rfnoc_pdu_tx_impl(dev, tx_stream_args, rx_stream_args, block_name, block_select, device_select)
+      );
+    }
+    static ::uhd::stream_args_t
+    _make_stream_args(const char *host_type, const char *otw_type, size_t spp, size_t len)
+    {
+      ::uhd::stream_args_t stream_args(host_type, otw_type);
+      stream_args.args["spp"] = str(boost::format("%s") % spp);
+      if (len > 1) {
+        stream_args.channels.clear();
+        for (size_t i=0; i<len; i++)
+          stream_args.channels.push_back(i);
+      }
+      return stream_args;
+    }
+
+
+    rfnoc_pdu_tx_impl::rfnoc_pdu_tx_impl(
+        const device3::sptr &dev,
+        const ::uhd::stream_args_t &tx_stream_args,
+        const ::uhd::stream_args_t &rx_stream_args,
+        const std::string &block_name,
+        const int block_select,
+        const int device_select
+    ) : rfnoc_block("rfnoc_pdu_tx"),
+        rfnoc_block_impl(
+            dev,
+            rfnoc_block_impl::make_block_id(block_name, block_select, device_select),
+	    tx_stream_args,
+	    rx_stream_args
+        )
+    {
+      message_port_register_in(pmt::mp("data"));
+      set_msg_handler(
+        pmt::mp("data"),
+        boost::bind(&rfnoc_pdu_tx_impl::handle_data_message, this, _1)
+      );
+
+      set_input_signature(io_signature::make (0, 0, 0));
+      //set_output_signature(io_signature::make(0, 0, 0));
+    }
+
+    rfnoc_pdu_tx_impl::~rfnoc_pdu_tx_impl()
+    {
+      /* nop */
+    }
+
+
+    size_t itemsize(vector_type type)
+    {
+      switch(type) {
+      case byte_t:
+        return sizeof(char);
+      case float_t:
+        return sizeof(float);
+      case complex_t:
+        return sizeof(gr_complex);
+      default:
+        throw std::runtime_error("bad PDU type");
+      }
+    }
+
+    vector_type type_from_pmt(pmt::pmt_t vector)
+    {
+      if(pmt::is_u8vector(vector))
+        return byte_t;
+      if(pmt::is_f32vector(vector))
+        return float_t;
+      if(pmt::is_c32vector(vector))
+        return complex_t;
+      throw std::runtime_error("bad PDU type");
+    }
+
+    void rfnoc_pdu_tx_impl::handle_data_message(pmt::pmt_t msg)
+    {
+      pmt::pmt_t vector = pmt::cdr(msg);
+
+      size_t offset(0);
+      size_t isize(itemsize(type_from_pmt(vector)));
+      int len(pmt::length(vector)*isize);
+
+      // printf("pdu impl data message %lu, %lu, %d\n", offset, isize, len);
+      // std::cout << boost::format("pdu impl data message %lu, %lu, %d") % offset % isize % len << std::endl;
+
+      const size_t num_sent = _tx.streamers[0]->send(
+          pmt::uniform_vector_elements(vector, offset),
+          len * _tx.vlen,
+          _tx.metadata,
+          1.0);
+      // std::cout << boost::format("Send %lu bytes") % num_sent << std::endl;
+    }
+
+    bool rfnoc_pdu_tx_impl::start()
+    {
+      boost::recursive_mutex::scoped_lock lock(d_mutex);
+      size_t ninputs  = 1;
+      size_t noutputs = 0;
+      GR_LOG_DEBUG(d_debug_logger, str(boost::format("start(): ninputs == %d noutputs == %d") % ninputs % noutputs));
+
+      // If the topology changed, we need to clear the old streamers
+      if (_rx.streamers.size() != noutputs) {
+        _rx.streamers.clear();
+      }
+      if (_tx.streamers.size() != ninputs) {
+        _tx.streamers.clear();
+      }
+
+      //////////////////// TX ///////////////////////////////////////////////////////////////
+      // Setup TX streamer.
+      if (ninputs && _tx.streamers.empty()) {
+        // Get a block control for the tx side:
+        ::uhd::rfnoc::sink_block_ctrl_base::sptr tx_blk_ctrl =
+            boost::dynamic_pointer_cast< ::uhd::rfnoc::sink_block_ctrl_base >(_blk_ctrl);
+        if (!tx_blk_ctrl) {
+          GR_LOG_FATAL(d_logger, str(boost::format("Not a sink_block_ctrl_base: %s") % _blk_ctrl->unique_id()));
+          return false;
+        }
+        if (_tx.align) { // Aligned streamers:
+          GR_LOG_DEBUG(d_debug_logger, str(boost::format("Creating one aligned tx streamer for %d inputs.") % ninputs));
+          GR_LOG_DEBUG(d_debug_logger,
+              str(boost::format("cpu: %s  otw: %s  args: %s channels.size: %d ") % _tx.stream_args.cpu_format % _tx.stream_args.otw_format % _tx.stream_args.args.to_string() % _tx.stream_args.channels.size()));
+          assert(ninputs == _tx.stream_args.channels.size());
+          ::uhd::tx_streamer::sptr tx_stream = _dev->get_tx_stream(_tx.stream_args);
+          if (tx_stream) {
+            _tx.streamers.push_back(tx_stream);
+          } else {
+            GR_LOG_FATAL(d_logger, str(boost::format("Can't create tx streamer(s) to: %s") % _blk_ctrl->get_block_id().get()));
+            return false;
+          }
+        } else { // Unaligned streamers:
+          for (size_t i = 0; i < size_t(ninputs); i++) {
+            _tx.stream_args.channels = std::vector<size_t>(1, i);
+            _tx.stream_args.args["block_port"] = str(boost::format("%d") % i);
+            GR_LOG_DEBUG(d_debug_logger, str(boost::format("creating tx streamer with: %s") % _tx.stream_args.args.to_string()));
+            ::uhd::tx_streamer::sptr tx_stream = _dev->get_tx_stream(_tx.stream_args);
+            if (tx_stream) {
+              _tx.streamers.push_back(tx_stream);
+            }
+          }
+          if (_tx.streamers.size() != size_t(ninputs)) {
+            GR_LOG_FATAL(d_logger, str(boost::format("Can't create tx streamer(s) to: %s") % _blk_ctrl->get_block_id().get()));
+            return false;
+          }
+        }
+      }
+
+      _tx.metadata.start_of_burst = false;
+      _tx.metadata.end_of_burst = false;
+      _tx.metadata.has_time_spec = false;
+
+      return true;
+    }
+
+  } /* namespace ettus */
+} /* namespace gr */
+

--- a/lib/rfnoc_pdu_tx_impl.h
+++ b/lib/rfnoc_pdu_tx_impl.h
@@ -1,0 +1,54 @@
+/* -*- c++ -*- */
+/* Copyright 2015 Ettus Research
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * gr-ettus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-ettus; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_ETTUS_RFNOC_PDU_IMPL_H
+#define INCLUDED_ETTUS_RFNOC_PDU_IMPL_H
+
+#include <ettus/rfnoc_pdu_tx.h>
+#include <ettus/rfnoc_block_impl.h>
+
+namespace gr {
+  namespace ettus {
+
+    enum vector_type { byte_t, float_t, complex_t };
+
+    class rfnoc_pdu_tx_impl : public rfnoc_pdu_tx, public rfnoc_block_impl
+    {
+     public:
+      rfnoc_pdu_tx_impl(         
+        const device3::sptr &dev,
+        const ::uhd::stream_args_t &tx_stream_args,
+	const ::uhd::stream_args_t &rx_stream_args,
+	const std::string &block_name,
+	const int block_select,
+        const int device_select=-1
+      );
+      bool start();
+      ~rfnoc_pdu_tx_impl();
+
+
+     private:
+      void handle_data_message(pmt::pmt_t msg);
+    };
+
+  } // namespace ettus
+} // namespace gr
+
+#endif /* INCLUDED_ETTUS_RFNOC_PDU_IMPL_H */
+

--- a/swig/ettus_swig.i
+++ b/swig/ettus_swig.i
@@ -57,6 +57,8 @@
 #include "ettus/rfnoc_block.h"
 #include "ettus/rfnoc_block_impl.h"
 #include "ettus/rfnoc_fosphor_c.h"
+#include "ettus/rfnoc_pdu_tx.h"
+#include "ettus/rfnoc_pdu_rx.h"
 %}
 
 #ifdef ENABLE_QT
@@ -137,6 +139,10 @@ GR_SWIG_BLOCK_MAGIC2(ettus, rfnoc_radio);
 GR_SWIG_BLOCK_MAGIC2(ettus, rfnoc_generic);
 %include "ettus/rfnoc_fosphor_c.h"
 GR_SWIG_BLOCK_MAGIC2(ettus, rfnoc_fosphor_c);
+%include "ettus/rfnoc_pdu_tx.h"
+GR_SWIG_BLOCK_MAGIC2(ettus, rfnoc_pdu_tx);
+%include "ettus/rfnoc_pdu_rx.h"
+GR_SWIG_BLOCK_MAGIC2(ettus, rfnoc_pdu_rx);
 
 #ifdef ENABLE_QT
 %include "ettus/fosphor_display.h"


### PR DESCRIPTION
These commits introduce two new software blocks that provide an alternate method of calling the send and recv methods of the tx_streamer and rx_streamer, respectively, using PDU message handlers and publishers instead of the rfnoc_block_impl work function. 

Commit 1 exposes functions and variables of the rfnoc_block_impl base class to derived classes. Namely the work functions and the stop/start functions become virtual. Also, member variables which were previously declared private are changed to be "protected" variables. We applied the protected label aggressively here-- I'm not sure where we would want to draw the line saying that member variables cannot ever be accessed by child classes. I'd be open to other thoughts here. At a minimum, we need ability to derive from rfnoc_block_impl, override work functions, and access the tx/rx streamers.

Commit 2 adds the rfnoc_pdu_rx and rfnoc_pdu_tx blocks. These are software blocks that attach to RFNoC FIFOs -- they can convert directly from PDUs into RFNoC packets and vice versa. RFNoC "spp" is indicated by the PDU length, making this approach ideal for variable length messages or for bursty data transfer to the FPGA. Here's an example "loopback" application in GRC:

![image](https://user-images.githubusercontent.com/613471/36388278-58f8d21e-1569-11e8-8e84-c1d15f671f29.png)

As always, feedback is appreciated. Thanks!