### PR TITLE
fosphor_display: Filter received tags by EOB

### DIFF
--- a/lib/fosphor_display_impl.cc
+++ b/lib/fosphor_display_impl.cc
@@ -223,7 +223,7 @@ namespace gr {
         return 0;
 
       /* Grab all tags available, we'll need them either way */
-      get_tags_in_range(v, port, nR, nR + n_items);
+      get_tags_in_range(v, port, nR, nR + n_items, EOB_KEY);
 
       /* If not aligned we just search for EOF */
       if (!this->d_aligned) {


### PR DESCRIPTION
Hi all, this is based on a discussion I had recently on the IRC about fosphor debugging... 

I have a local change to gr-ettus that outputs timetag/sample rate item tags on the output of each rx_streamer, which broke fosphor... It turns out fosphor is using item tags for framing, but was not filtering based on end-of-burst.

This quick fix will let us add other item tags to gnuradio streams going into the fosphor display without breaking fosphor. 