### PR TITLE
pdu_rx/pdu_tx: Fix GRC blocks to avoid template error

### DIFF
--- a/grc/uhd_rfnoc_pdu_rx.xml
+++ b/grc/uhd_rfnoc_pdu_rx.xml
@@ -9,12 +9,12 @@
     uhd.stream_args( \# Tx Stream Args
         cpu_format="$type",
         otw_format="$otw_format",
-	args=""
+        args=""
     ),
     uhd.stream_args( \# Rx Stream Args
         cpu_format="$type",
         otw_format="$otw_format",
-        args=${stream_args}
+        args=""
     ),
     "FIFO",
     $block_index, $device_index, $mtu)

--- a/grc/uhd_rfnoc_pdu_tx.xml
+++ b/grc/uhd_rfnoc_pdu_tx.xml
@@ -9,7 +9,7 @@
     uhd.stream_args( \# Tx Stream Args
         cpu_format="$type",
         otw_format="$otw_format",
-        args=${stream_args}
+        args=""
     ),
     uhd.stream_args( \# Rx Stream Args
         cpu_format="$type",


### PR DESCRIPTION
Sadly, the initial commit for PDU tx/rx blocks created a GRC template error (there's no stream_args variable in the GRC block). My apologies! This commit fixes the template error.