### PR TITLE
Fix bug in code template,rfnocmodtool

### DIFF
--- a/python/rfnoc_modtool/templates.py
+++ b/python/rfnoc_modtool/templates.py
@@ -571,7 +571,7 @@ module noc_block_${blockname} #(
     // Computer Engine Clock Domain
     .clk(ce_clk), .reset(ce_rst),
     // Control Sink
-    .set_data(set_data), .set_addr(set_addr), .set_stb(set_stb), set_time(), .set_has_time(),
+    .set_data(set_data), .set_addr(set_addr), .set_stb(set_stb), .set_time(), .set_has_time(),
     .rb_stb(1'b1), .rb_data(rb_data), .rb_addr(rb_addr),
     // Control Source
     .cmdout_tdata(cmdout_tdata), .cmdout_tlast(cmdout_tlast), .cmdout_tvalid(cmdout_tvalid), .cmdout_tready(cmdout_tready),


### PR DESCRIPTION
Fix bug in code template,rfnocmodtool: fail in Vivado 2017.4 XSim --> "port connections cannot be mixed ordered and named".