### PR TITLE
Fix grc/uhd_rfnoc_radio

### DIFF
--- a/grc/uhd_rfnoc_radio.xml
+++ b/grc/uhd_rfnoc_radio.xml
@@ -40,8 +40,9 @@ self.$(id).set_${direction}_dc_offset($dcenable1, 1)
 
 #if (str($direction()) == "rx")
 self.$(id).set_rx_bandwidth($rx_bandwidth0, 0)
-#else if ($num_channels() > 1):
+#if ($num_channels() > 1):
 self.$(id).set_rx_bandwidth($rx_bandwidth1, 1)
+#end if
 #end if
 
 self.$(id).set_${direction}_antenna($ant0, 0)

--- a/grc/uhd_rfnoc_radio.xml
+++ b/grc/uhd_rfnoc_radio.xml
@@ -247,7 +247,8 @@ self.$(id).set_rx_lo_source($lo_source1, "all", 1)
   <param>
     <name>Ch0: Antenna</name>
     <key>ant0</key>
-    <type>enum</type>
+    <value></value>
+    <type>string</type>
     <hide>
       #if not $num_channels() >= 1
         all
@@ -368,7 +369,8 @@ self.$(id).set_rx_lo_source($lo_source1, "all", 1)
   <param>
     <name>Ch1: Antenna</name>
     <key>ant1</key>
-    <type>enum</type>
+    <value></value>
+    <type>string</type>
     <hide>
       #if not $num_channels() >= 2
       all


### PR DESCRIPTION
The first patch is to allows user to specify explicitly an antenna name depending on daughterboard. For example BasicRX names are limited to A, B and AB. Using an other value will result on a gnuradio fail at start time.

The second patch is to fix rx_bandwidth configuration in RX mode when more than one channel is used. Without this, set_rx_bandwitdh is only called when radio is in TX mode and 2 channels are used.