### PR TITLE
Allowing to disable the sending of end of burst packet

### DIFF
--- a/include/ettus/rfnoc_block_impl.h
+++ b/include/ettus/rfnoc_block_impl.h
@@ -75,7 +75,7 @@ namespace gr {
               const std::string &block_id,
               const ::uhd::stream_args_t &tx_stream_args,
               const ::uhd::stream_args_t &rx_stream_args,
-              const bool end_of_burst_enabled = true
+              const bool enable_eob_on_stop = true
       );
 
       /*********************************************************************
@@ -238,7 +238,7 @@ namespace gr {
 
       /*** Stream commands *********************************/
       bool _start_time_set;
-      bool _end_of_burst_enabled;
+      bool _enable_eob_on_stop;
       ::uhd::time_spec_t _start_time;
 
       /*** Multi-Streamer Sync and concurrency stuff ********/

--- a/include/ettus/rfnoc_block_impl.h
+++ b/include/ettus/rfnoc_block_impl.h
@@ -74,7 +74,8 @@ namespace gr {
               const device3::sptr &dev,
               const std::string &block_id,
               const ::uhd::stream_args_t &tx_stream_args,
-              const ::uhd::stream_args_t &rx_stream_args
+              const ::uhd::stream_args_t &rx_stream_args,
+              const bool end_of_burst_enabled = true
       );
 
       /*********************************************************************
@@ -237,6 +238,7 @@ namespace gr {
 
       /*** Stream commands *********************************/
       bool _start_time_set;
+      bool _end_of_burst_enabled;
       ::uhd::time_spec_t _start_time;
 
       /*** Multi-Streamer Sync and concurrency stuff ********/

--- a/lib/rfnoc_block_impl.cc
+++ b/lib/rfnoc_block_impl.cc
@@ -144,12 +144,12 @@ rfnoc_block_impl::rfnoc_block_impl(
     const std::string &block_id,
     const ::uhd::stream_args_t &tx_stream_args,
     const ::uhd::stream_args_t &rx_stream_args,
-    const bool end_of_burst_enabled
+    const bool enable_eob_on_stop
 ) : _dev(dev->get_device()),
     _tx(tx_stream_args),
     _rx(rx_stream_args),
     _start_time_set(false),
-    _end_of_burst_enabled(end_of_burst_enabled)
+    _enable_eob_on_stop(enable_eob_on_stop)
 {
   std::vector< ::uhd::rfnoc::block_id_t > blocks =
           dev->get_device()->find_blocks(block_id);
@@ -381,7 +381,7 @@ bool rfnoc_block_impl::stop()
   }
 
   // TX: Send EOB
-  if (_end_of_burst_enabled) {
+  if (_enable_eob_on_stop) {
     _tx.metadata.start_of_burst = false;
     _tx.metadata.end_of_burst = true;
     _tx.metadata.has_time_spec = false;

--- a/python/rfnoc_modtool/templates.py
+++ b/python/rfnoc_modtool/templates.py
@@ -96,7 +96,8 @@ namespace gr {
         ${strip_default_values(arglist)},
 % endif
         const int block_select,
-        const int device_select
+        const int device_select,
+        const bool end_of_burst_enabled
       );
       ~${blockname}_impl();
 
@@ -130,7 +131,8 @@ namespace gr {
         ${strip_default_values(arglist)},
 % endif
         const int block_select,
-        const int device_select
+        const int device_select,
+        const bool end_of_burst_enabled
     )
     {
       return gnuradio::get_initial_sptr(
@@ -142,7 +144,8 @@ namespace gr {
             ${strip_arg_types(arglist)},
 % endif
             block_select,
-            device_select
+            device_select,
+            end_of_burst_enabled
         )
       );
     }
@@ -158,13 +161,14 @@ namespace gr {
          ${strip_default_values(arglist)},
 % endif
          const int block_select,
-         const int device_select
+         const int device_select,
+         const bool end_of_burst_enabled
     )
       : gr::ettus::rfnoc_block("${blockname}"),
         gr::ettus::rfnoc_block_impl(
             dev,
             gr::ettus::rfnoc_block_impl::make_block_id("${blockname}",  block_select, device_select),
-            tx_stream_args, rx_stream_args
+            tx_stream_args, rx_stream_args, end_of_burst_enabled
             )
     {}
 
@@ -221,7 +225,8 @@ namespace gr {
         ${arglist},
 % endif
         const int block_select=-1,
-        const int device_select=-1
+        const int device_select=-1,
+        const bool end_of_burst_enabled=true
         );
     };
   } // namespace ${modname}
@@ -389,7 +394,8 @@ Templates['grc_xml'] = '''<?xml version="1.0"?>
           ${strip_arg_types_grc(arglist)},
 % endif
  <%text>         $block_index,
-          $device_index
+          $device_index,
+          $end_of_burst_enabled
   )</make>
   <!-- Make one 'param' node for every Parameter you want settable from the GUI.
        Sub-nodes:
@@ -438,6 +444,15 @@ Templates['grc_xml'] = '''<?xml version="1.0"?>
     <value>-1</value>
     <type>int</type>
     <hide>#if int($block_index()) &lt; 0 then 'part' else 'none'#</hide>
+    <tab>RFNoC Config</tab>
+  </param>
+</%text>
+  <param>
+    <name>End of Burst Enable</name><%text>
+    <key>end_of_burst_enabled</key>
+    <value>True</value>
+    <type>bool</type>
+    <hide>#if $end_of_burst_enabled() == True then 'part' else 'none'#</hide>
     <tab>RFNoC Config</tab>
   </param>
 </%text>

--- a/python/rfnoc_modtool/templates.py
+++ b/python/rfnoc_modtool/templates.py
@@ -97,7 +97,7 @@ namespace gr {
 % endif
         const int block_select,
         const int device_select,
-        const bool end_of_burst_enabled
+        const bool enable_eob_on_stop
       );
       ~${blockname}_impl();
 
@@ -132,7 +132,7 @@ namespace gr {
 % endif
         const int block_select,
         const int device_select,
-        const bool end_of_burst_enabled
+        const bool enable_eob_on_stop
     )
     {
       return gnuradio::get_initial_sptr(
@@ -145,7 +145,7 @@ namespace gr {
 % endif
             block_select,
             device_select,
-            end_of_burst_enabled
+            enable_eob_on_stop
         )
       );
     }
@@ -162,13 +162,13 @@ namespace gr {
 % endif
          const int block_select,
          const int device_select,
-         const bool end_of_burst_enabled
+         const bool enable_eob_on_stop
     )
       : gr::ettus::rfnoc_block("${blockname}"),
         gr::ettus::rfnoc_block_impl(
             dev,
             gr::ettus::rfnoc_block_impl::make_block_id("${blockname}",  block_select, device_select),
-            tx_stream_args, rx_stream_args, end_of_burst_enabled
+            tx_stream_args, rx_stream_args, enable_eob_on_stop
             )
     {}
 
@@ -226,7 +226,7 @@ namespace gr {
 % endif
         const int block_select=-1,
         const int device_select=-1,
-        const bool end_of_burst_enabled=true
+        const bool enable_eob_on_stop=true
         );
     };
   } // namespace ${modname}
@@ -395,7 +395,7 @@ Templates['grc_xml'] = '''<?xml version="1.0"?>
 % endif
  <%text>         $block_index,
           $device_index,
-          $end_of_burst_enabled
+          $enable_eob_on_stop
   )</make>
   <!-- Make one 'param' node for every Parameter you want settable from the GUI.
        Sub-nodes:
@@ -449,10 +449,10 @@ Templates['grc_xml'] = '''<?xml version="1.0"?>
 </%text>
   <param>
     <name>End of Burst Enable</name><%text>
-    <key>end_of_burst_enabled</key>
+    <key>enable_eob_on_stop</key>
     <value>True</value>
     <type>bool</type>
-    <hide>#if $end_of_burst_enabled() == True then 'part' else 'none'#</hide>
+    <hide>#if $enable_eob_on_stop() == True then 'part' else 'none'#</hide>
     <tab>RFNoC Config</tab>
   </param>
 </%text>

--- a/python/rfnoc_modtool/templates.py
+++ b/python/rfnoc_modtool/templates.py
@@ -448,7 +448,7 @@ Templates['grc_xml'] = '''<?xml version="1.0"?>
   </param>
 </%text>
   <param>
-    <name>End of Burst Enable</name><%text>
+    <name>Enable EOB on Stop</name><%text>
     <key>enable_eob_on_stop</key>
     <value>True</value>
     <type>bool</type>


### PR DESCRIPTION
### Motivation
For certain use cases of RFNoC blocks the data expected by the block is only in terms of streams. This is the case by default while using AXI Wrappers' simple mode when the user does not intend to interact with the headers of the packets and is concerned only with the payload of the packets.

In such applications when the user is not intending to use the headers an additional packet that is sent as the end of burst produces unexpected results. The situation is worsened upon implementation of state machines that depend on receiving certain number of packets.

The problem can be resolved in hardware block by consuming/ignoring the end of burst packet, but that still results in performing operations that are not relevant to intended designs.

### Proposed solution
* Instead of always sending the end of burst packet, a parameter is used to determine whether or not the end of burst packet should be sent or not.
* This parameter has been assigned a default value that performs the existing functionality of sending the burst packet, while it can be now configured to not send that packet if the user so wishes.

### Testing
* The changes have been tested on the latest tools installed with pybombs as indicated in the "Getting Started with RFNoC Development" (https://kb.ettus.com/Getting_Started_with_RFNoC_Development) tutorial on a X300 Board with GnuRadio Companion.