### PR TITLE
Various fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,9 @@ if(ENABLE_QT)
     if (QT_FOUND)
 	include(GrSetupQt4)
     endif (QT_FOUND)
+    if(APPLE)
+      list(APPEND QT_LIBRARIES "-framework OpenGL")
+    endif(APPLE)
 endif(ENABLE_QT)
 
 ########################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,14 +187,12 @@ include_directories(
     ${CMAKE_BINARY_DIR}/lib
     ${CMAKE_BINARY_DIR}/include
     ${Boost_INCLUDE_DIRS}
-    ${CPPUNIT_INCLUDE_DIRS}
     ${GNURADIO_ALL_INCLUDE_DIRS}
     ${UHD_INCLUDE_DIRS}
 )
 
 link_directories(
     ${Boost_LIBRARY_DIRS}
-    ${CPPUNIT_LIBRARY_DIRS}
     ${GNURADIO_RUNTIME_LIBRARY_DIRS}
 )
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -31,8 +31,6 @@ if(ENABLE_QT)
     include_directories(${QT_INCLUDE_DIRS})
 endif(ENABLE_QT)
 
-include_directories(${Boost_INCLUDE_DIR})
-link_directories(${Boost_LIBRARY_DIRS})
 list(APPEND ettus_sources
     device3.cc
     rfnoc_block_impl.cc

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -104,6 +104,8 @@ if(CPPUNIT_FOUND)
 
     include_directories(${CPPUNIT_INCLUDE_DIRS})
 
+    link_directories(${CPPUNIT_LIBRARY_DIRS})
+
     list(APPEND test_ettus_sources
         ${CMAKE_CURRENT_SOURCE_DIR}/test_ettus.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/qa_ettus.cc

--- a/python/rfnoc_modtool/rfnoc-newmod/CMakeLists.txt
+++ b/python/rfnoc_modtool/rfnoc-newmod/CMakeLists.txt
@@ -125,10 +125,6 @@ set(GR_REQUIRED_COMPONENTS RUNTIME)
 find_package(Gnuradio "3.7.2" REQUIRED)
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
-if(NOT CPPUNIT_FOUND)
-    message(FATAL_ERROR "CppUnit required to compile rfnoc_example")
-endif()
-
 ########################################################################
 # Setup doxygen option
 ########################################################################
@@ -147,13 +143,11 @@ include_directories(
     ${CMAKE_BINARY_DIR}/lib
     ${CMAKE_BINARY_DIR}/include
     ${Boost_INCLUDE_DIRS}
-    ${CPPUNIT_INCLUDE_DIRS}
     ${GNURADIO_ALL_INCLUDE_DIRS}
 )
 
 link_directories(
     ${Boost_LIBRARY_DIRS}
-    ${CPPUNIT_LIBRARY_DIRS}
     ${GNURADIO_RUNTIME_LIBRARY_DIRS}
 )
 

--- a/python/rfnoc_modtool/rfnoc-newmod/lib/CMakeLists.txt
+++ b/python/rfnoc_modtool/rfnoc-newmod/lib/CMakeLists.txt
@@ -22,12 +22,8 @@
 ########################################################################
 include(GrPlatform) #define LIB_SUFFIX
 
-include_directories(${Boost_INCLUDE_DIR})
-link_directories(${Boost_LIBRARY_DIRS})
-
 list(APPEND rfnoc_example_sources
 )
-
 
 set(rfnoc_example_sources "${rfnoc_example_sources}" PARENT_SCOPE)
 if(NOT rfnoc_example_sources)

--- a/python/rfnoc_modtool/rfnoc-newmod/lib/CMakeLists.txt
+++ b/python/rfnoc_modtool/rfnoc-newmod/lib/CMakeLists.txt
@@ -57,27 +57,33 @@ install(TARGETS gnuradio-rfnoc_example
 ########################################################################
 # Build and register unit test
 ########################################################################
-include(GrTest)
+if(CPPUNIT_FOUND)
 
-include_directories(${CPPUNIT_INCLUDE_DIRS})
+    include(GrTest)
 
-list(APPEND test_rfnoc_example_sources
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_rfnoc_example.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/qa_rfnoc_example.cc
-)
+    include_directories(${CPPUNIT_INCLUDE_DIRS})
 
-add_executable(test-rfnoc_example ${test_rfnoc_example_sources})
+    link_directories(${CPPUNIT_LIBRARY_DIRS})
 
-target_link_libraries(
-  test-rfnoc_example
-  ${GNURADIO_RUNTIME_LIBRARIES}
-  ${Boost_LIBRARIES}
-  ${CPPUNIT_LIBRARIES}
-  ${ETTUS_LIBRARIES}
-  ${PC_ETTUS_LIBDIR}
-  gnuradio-rfnoc_example
-)
+    list(APPEND test_rfnoc_example_sources
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_rfnoc_example.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/qa_rfnoc_example.cc
+    )
 
+    add_executable(test-rfnoc_example ${test_rfnoc_example_sources})
 
+    target_link_libraries(
+        test-rfnoc_example
+        ${GNURADIO_RUNTIME_LIBRARIES}
+        ${Boost_LIBRARIES}
+        ${CPPUNIT_LIBRARIES}
+        ${ETTUS_LIBRARIES}
+        ${PC_ETTUS_LIBDIR}
+        gnuradio-rfnoc_example
+    )
 
-GR_ADD_TEST(test_rfnoc_example test-rfnoc_example)
+    GR_ADD_TEST(test_rfnoc_example test-rfnoc_example)
+
+else(CPPUNIT_FOUND)
+    message(WARNING "Disabling unit tests: No CppUnit found.")
+endif(CPPUNIT_FOUND)


### PR DESCRIPTION
* allowing CMake to not error out if CppUnit is not found.
* removing redundancy.
* Fixing build on OSX.