### PR TITLE
fir filter: Allow building against all UHD versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,17 +95,10 @@ endif(APPLE)
 ########################################################################
 # Find gr-ettus build dependencies
 ########################################################################
-find_package(UHD "4.2" REQUIRED)
+find_package(UHD "4.0" REQUIRED)
 if(NOT UHD_FOUND)
-    message(FATAL_ERROR "UHD >= 4.2 not found.")
+    message(FATAL_ERROR "UHD >= 4.0 not found.")
 endif(NOT UHD_FOUND)
-# The maint-3.8-uhd4.0 branch of gr-ettus is compatible only with UHD
-# versions greater than 4.0 and less than 4.2. Perform an explicit check
-# here, as specifying a version range in find_package() is only supported
-# with CMake 3.19 or later.
-if(NOT UHD_VERSION VERSION_LESS "4.2")
-    MESSAGE(FATAL_ERROR "UHD version must be at least 4.0 but less than 4.2 (found version ${UHD_VERSION}).")
-endif(NOT UHD_VERSION VERSION_LESS "4.2")
 
 find_package(PythonLibs 2)
 if(NOT PYTHONLIBS_FOUND)

--- a/include/ettus/rfnoc_fir_filter.h
+++ b/include/ettus/rfnoc_fir_filter.h
@@ -51,24 +51,30 @@ public:
     /*! Set the FIR Filter coefficients
      *
      * \param coeffs Vector of Coeffs (float)
+     * \param chan   Channel Index
      */
-    virtual void set_coefficients(const std::vector<float>& coeffs) = 0;
+    virtual void set_coefficients(const std::vector<float>& coeffs,
+                                  const size_t chan = 0) = 0;
 
     /*! Set the FIR Filter coefficients
      *
      * \param coeffs Vector of Coeffs (int16)
+     * \param chan   Channel Index
      */
-    virtual void set_coefficients(const std::vector<int16_t>& coeffs) = 0;
+    virtual void set_coefficients(const std::vector<int16_t>& coeffs,
+                                  const size_t chan = 0) = 0;
 
     /*! Get the number of FIR Filter coefficients
      *
+     * \param chan   Channel Index
      */
-    virtual size_t get_max_num_coefficients() = 0;
+    virtual size_t get_max_num_coefficients(const size_t chan = 0) = 0;
 
     /*! Returns a vector of FIR Filter coefficients
      *
+     * \param chan   Channel Index
      */
-    virtual std::vector<int16_t> get_coefficients() = 0;
+    virtual std::vector<int16_t> get_coefficients(const size_t chan = 0) = 0;
 };
 
 } // namespace ettus

--- a/lib/rfnoc_fir_filter_impl.h
+++ b/lib/rfnoc_fir_filter_impl.h
@@ -35,10 +35,10 @@ public:
     ~rfnoc_fir_filter_impl();
 
     /*** API *****************************************************************/
-    void set_coefficients(const std::vector<float>& coeffs);
-    void set_coefficients(const std::vector<int16_t>& coeffs);
-    size_t get_max_num_coefficients();
-    std::vector<int16_t> get_coefficients();
+    void set_coefficients(const std::vector<float>& coeffs, const size_t chan);
+    void set_coefficients(const std::vector<int16_t>& coeffs, const size_t chan);
+    size_t get_max_num_coefficients(const size_t chan);
+    std::vector<int16_t> get_coefficients(const size_t chan);
 
 private:
     ::uhd::rfnoc::fir_filter_block_control::sptr d_fir_filter_ref;


### PR DESCRIPTION
This uses UHD_VERSION to determine if UHD's FIR filter block controller
has a multi-channel API or not.
All channel arguments on the GNU Radio block are now zero (from
previously no default).

When using UHD 4.1 or 4.0, and trying to access an invalid channel
index, a bespoke warning is printed to the GR logger.

This also reverts e92e957.