### PR TITLE
streamers: Allow specifying adapter IDs

### DIFF
--- a/grc/ettus_rfnoc_rx_streamer.block.yml
+++ b/grc/ettus_rfnoc_rx_streamer.block.yml
@@ -18,6 +18,11 @@ templates:
         ${ vlen },
         True
     )
+    %if use_default_adapter_id == 'False':
+    for port, adapter_id in enumerate(${ adapter_id_list }):
+        self.rfnoc_graph.set_streamer_adapter_id(
+            self.${id}.get_unique_id(), port, adapter_id)
+    %endif
 
 parameters:
 - id: num_chans
@@ -50,9 +55,24 @@ parameters:
   option_attributes:
     type: [fc32, sc16, s8]
   hide: part
+- id: use_default_adapter_id
+  label: Default Adapter ID
+  dtype: bool
+  default: 'True'
+  options: ['True', 'False']
+  option_labels: ['Yes', 'No']
+  hide: part
+- id: adapter_id_list
+  label: Adapter ID List
+  dtype: int_vector
+  default: [0,]
+  hide: ${ 'all' if use_default_adapter_id else 'none' }
+
 
 asserts:
   - ${ num_chans > 0 }
+  - ${ vlen > 0 }
+  - ${ use_default_adapter_id or len(adapter_id_list) == num_chans }
 
 inputs:
 - domain: rfnoc

--- a/grc/ettus_rfnoc_tx_streamer.block.yml
+++ b/grc/ettus_rfnoc_tx_streamer.block.yml
@@ -17,6 +17,11 @@ templates:
         ),
         ${ vlen }
     )
+    %if use_default_adapter_id == 'False':
+    for port, adapter_id in enumerate(${ adapter_id_list }):
+        self.rfnoc_graph.set_streamer_adapter_id(
+            self.${id}.get_unique_id(), port, adapter_id)
+    %endif
 
 parameters:
 - id: num_chans
@@ -49,6 +54,18 @@ parameters:
   option_attributes:
     type: ['', sc16]
   hide: part
+- id: use_default_adapter_id
+  label: Default Adapter ID
+  dtype: bool
+  default: 'True'
+  options: ['True', 'False']
+  option_labels: ['Yes', 'No']
+  hide: part
+- id: adapter_id_list
+  label: Adapter ID List
+  dtype: int_vector
+  default: [0,]
+  hide: ${ 'all' if use_default_adapter_id else 'none' }
 
 inputs:
 - domain: stream

--- a/include/ettus/rfnoc_graph.h
+++ b/include/ettus/rfnoc_graph.h
@@ -24,6 +24,7 @@
 
 #include <ettus/api.h>
 #include <uhd/rfnoc/noc_block_base.hpp>
+#include <uhd/rfnoc_graph.hpp>
 #include <uhd/stream.hpp>
 #include <uhd/types/device_addr.hpp>
 #include <boost/shared_ptr.hpp>
@@ -44,6 +45,9 @@ public:
     using sptr = boost::shared_ptr<rfnoc_graph>;
 
     static sptr make(const ::uhd::device_addr_t& dev_addr);
+
+    static const size_t NULL_ADAPTER_ID =
+        static_cast<size_t>(::uhd::transport::NULL_ADAPTER_ID);
 
     virtual ~rfnoc_graph() {}
 
@@ -92,6 +96,23 @@ public:
     // \param args Stream args.
     virtual ::uhd::tx_streamer::sptr
     create_tx_streamer(const size_t num_ports, const ::uhd::stream_args_t& args) = 0;
+
+    //! Set the desired adapter ID for a streamer connection
+    //
+    // If it is desired to connect a streamer to the device using a specific
+    // adapter ID, this method needs to be called before calling connect().
+    //
+    // For more detail on adapter IDs, see the UHD documentation (e.g.,
+    // ::uhd::rfnoc::rfnoc_graph::connect()). Note that this does not have a
+    // corresponding API call in UHD: There, the connect() call is atomic and
+    // takes the adapter ID as an argument. The reason this is different in the
+    // GNU Radio implementation is that this makes it much easier to generate
+    // code from GRC for C++ and Python. It reduces the number of connect calls
+    // down to 1 (from 3 in UHD) and allows the streamer blocks to set this
+    // property on the streamer-edges before connect calls are mader later on.
+    virtual void set_streamer_adapter_id(const std::string& stream_block_id,
+                                         const size_t port,
+                                         const size_t adapter_id) = 0;
 
     //! Commit the graph and run initial checks
     //


### PR DESCRIPTION
Includes the following changes:
- Add a set_streamer_adapter_id() API call to rfnoc_graph. This sets an adapter ID for later calls to connect().
- Amend the GRC bindings for the RX and TX streamers to allow specifying the adapter ID. It will call rfnoc_graph::set_streamer_adapter_id() to do so in the autogenerated Python code.

Signed-off-by: Martin Braun <martin.braun@ettus.com>

Fixes #56.